### PR TITLE
add expect_macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/rust-crates/ergo_std"
 version = "0.0.1"
 
 [dependencies]
+expect_macro = "0.1.0"
 itertools = "0.7"
 lazy_static = "1.0"
 maplit = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@
 //! - [**serde**](https://github.com/serde-rs/serde): Serialization framework for Rust
 //! - [**std_prelude**](https://github.com/vitiral/std_prelude): prelude that the rust stdlib
 //!   should have always had
+//! - [**expect_macro**](https://github.com/vitiral/expect_macro): The `expect!` macro
 //! - [**lazy_static**](https://github.com/rust-lang-nursery/lazy-static.rs): A small macro for
 //!   defining lazy evaluated static variables in Rust.
 //! - [**itertools**](https://github.com/bluss/rust-itertools): Extra iterator adaptors, iterator
@@ -70,6 +71,8 @@
 #![allow(unused_imports)]
 
 #[macro_use]
+pub extern crate expect_macro;
+#[macro_use]
 pub extern crate itertools;
 #[macro_use]
 pub extern crate lazy_static;
@@ -81,6 +84,7 @@ pub extern crate serde;
 #[macro_use]
 pub extern crate serde_derive;
 
+pub use expect_macro::*;
 pub use std_prelude::*;
 pub use lazy_static::*;
 pub use itertools::Itertools;


### PR DESCRIPTION
This PR adds the `expect!` macro, which is an ergonomic replacement for `unwrap()`/`expect()`. The main advantages are:

- Prints the line number/column of the failure with a better error message.
- Can specify format parameters (The type of `expect` is `expect(&str)`, so you have to use `&format!(...)`)
- Error conditions are lazily evaluated.

See the docs for expect_macro for more: http://docs.rs/expect_macro